### PR TITLE
Add gendatablocks and update dedupe_tests to use it for writing dedupe

### DIFF
--- a/src/dmtest/gendatablocks.py
+++ b/src/dmtest/gendatablocks.py
@@ -1,0 +1,499 @@
+""" Write test data to a device or file"""
+import os
+import struct
+
+from pathlib import Path
+from typing import List
+
+# According to pylint numpy should be last
+import numpy
+
+# Each data stream is identified by an 8 character tag
+MAX_TAG_SIZE = 8
+
+def shrink_for_dedupe(number: int, dedupe: float) -> int:
+    """Calculate the block number for the Header.
+
+    In general, if we end up with the same tag, stream number, and block number we will
+    have the same Header and thus the same 'random' data. This is how we generate
+    deduplicated data.
+
+    To accomplish this, the algorithm below maintains the appropriate fraction of unique
+    block numbers. The rest are halved, perhaps multiple times, to map unevenly onto
+    lower (previously used) block numbers
+
+    Parameters
+    ----------
+    number : int
+        The original block number
+    dedupe : float
+        The dedupe rate
+
+    Returns
+    -------
+    int
+        The calculated block number
+
+    """
+    while number > 0 and (number * dedupe) % 1 < dedupe:
+        number = number >> 1
+    return number
+
+class CompareError(Exception):
+    """ Exception raised for full data compare errors """
+    def __init__(self,
+                 block_number: int,
+                 actual: bytes,
+                 expected: bytes,
+                 byte_number: int):
+        self.block_number = block_number
+        self.actual = actual
+        self.expected = expected
+        self.byte_number = byte_number
+
+        def __str__(self) -> str:
+            """ __str__ is to print() the error """
+            return ("verification of block " + repr(self.block_number)
+                    + " failed. actual: " + repr(self.actual)
+                    + " expected: " + repr(self.expected) + " at byte "
+                    + repr(self.byte_number))
+
+class ClaimError(Exception):
+    """ Exception raised when no streams claim a block """
+    def __init__(self,
+                 block_number: int,
+                 actual: bytes):
+        self.block_number = block_number
+        self.actual = actual
+
+        def __str__(self) -> str:
+            """ __str__ is to print() the error """
+            return ("block " + repr(self.block_number)
+                    + " not claimed. actual: " + repr(self.actual))
+
+HEADER_FORMAT = "!8sIL"
+
+class Header:
+    """Header of what is written to and read from disk
+
+    The header is used to describe the block of data written to disk.
+
+    """
+    def __init__(self, tag: str, stream_number: int, block_number: int):
+        self.tag = tag
+        self.stream_number = stream_number
+        self.block_number = block_number
+
+    def get_seed(self) -> int:
+        """generate a seed based off the Header
+
+        Returns
+        -------
+        int
+            the seed calculated from the Header
+
+        """
+        return int.from_bytes(self.to_bytes())
+
+    def to_bytes(self) -> bytes:
+        """get a bytes array representation of the Header
+
+        Returns
+        -------
+        bytes
+            the bytes array representation
+
+        """
+        return struct.pack(HEADER_FORMAT, self.tag.encode('ascii'),
+                           self.stream_number, self.block_number)
+
+    @classmethod
+    def len_as_bytes(cls) -> int:
+        """get the length of the bytes representation of the Header
+
+        Returns
+        -------
+        int
+            the length of the bytes representation
+
+        """
+        return struct.calcsize(HEADER_FORMAT)
+
+    @classmethod
+    def from_bytes(cls, buffer):
+        """Generate a Header from a bytes array
+
+        Parameters
+        ----------
+        buffer : bytes
+            bytes read from disk
+
+        Returns
+        -------
+        Header
+            Header representing bytes read from disk
+
+        """
+        tag, stream_number, block_number = struct.unpack(HEADER_FORMAT, buffer)
+        return Header(tag.decode('ascii').rstrip('\0'), stream_number, block_number)
+
+class BlockBuffer:
+    """A variable length buffer of data that is written to and read from disk
+
+    It contains a fixed length header and a variable length data portion.
+
+    """
+    def __init__(self, header: 'Header', data: bytes = bytes()):
+        self.header = header
+        self.data = data
+
+    def fill_data(self, compress_size: int, block_size: int):
+        """Fill the variable length part of the buffer
+
+        This function fills the variable length part of the buffer with compressible and
+        random data. The first part is all 1s and is based on how much compression is
+        requested. The remaining data is random data generated using a seed based off of
+        the Header. The code will use similar Headers as a way of generating requested
+        dedupe rates.
+
+        Parameters
+        ----------
+        compress_size : int
+            the requested compression rate
+        block_size : int
+            the block size to write
+
+        """
+        rand_size = block_size - compress_size
+        header_len = Header.len_as_bytes()
+        if compress_size > 0:
+            compress_size = compress_size - header_len
+        else:
+            rand_size = rand_size - header_len
+
+        seed = self.header.get_seed()
+        rng = numpy.random.default_rng(seed)
+        self.data = bytes([255] * compress_size) + rng.bytes(rand_size)
+
+    def to_bytes(self) -> bytes:
+        """get a bytes array representation of the BlockBuffer
+
+        Returns
+        -------
+        bytes
+            the bytes array representation
+
+        """
+        return self.header.to_bytes() + self.data
+
+class DataStream:
+    """A generic data stream that operates on a BlockRange"""
+    def __init__(self):
+        self.counter = 0
+
+    def claim(self, buffer: bytes) -> bool:
+        raise NotImplementedError("method claim must be implemented")
+
+    def generate(self, block_number: int, block_size: int) -> bytes:
+        raise NotImplementedError("method generate must be implemented")
+
+    def report(self) -> str:
+        raise NotImplementedError("method report must be implemented")
+
+class BlockStream(DataStream):
+    """A data stream that may contain deduplicate and/or compressible data"""
+    def __init__(self,
+                 tag: str,
+                 dedupe: float = 0.0,
+                 compress: float = 0.0,
+                 direct: bool = False,
+                 sync: bool = False,
+                 fsync: bool = False):
+        self.tag = tag
+        self.dedupe = dedupe
+        self.compress = compress
+        self.direct = direct
+        self.sync = sync
+        self.fsync = fsync
+        self.number = 0
+        super().__init__()
+
+    def claim(self, buffer):
+        """Claim initial ownership of the data buffer
+
+        Parameters
+        ----------
+        buffer : bytes
+            a bytes representation of a BlockBuffer
+
+        Returns
+        -------
+        bool
+            True if the buffer has the same tag as this stream
+        """
+        header = Header.from_bytes(buffer[:Header.len_as_bytes()])
+        return header.tag == self.tag
+
+    def generate(self, block_number, block_size):
+        """Generate a buffer for the BlockStream at a given location
+
+        Parameters
+        ----------
+        block_number : int
+            location in the BlockStream to generate the buffer
+        block_size : int
+            size of the buffer to generate
+
+        Returns
+        -------
+        bytes
+            the bytes array
+        """
+        number = shrink_for_dedupe(block_number, self.dedupe)
+        header = Header(self.tag, self.number, number)
+        block = BlockBuffer(header)
+        # Fill the block with ones for compress and rest with random data
+        compress = int(self.compress * block_size)
+        block.fill_data(compress, block_size)
+        return block.to_bytes()
+
+    def report(self):
+        """Return information about the last write or verify"""
+        return (str(self.tag) + ":" + str(self.counter))
+
+class ZeroStream(DataStream):
+    """A data stream representing a new or trimmed device or file"""
+    def claim(self, buffer):
+        """Claim initial ownership of the data buffer
+
+        Parameters
+        ----------
+        buffer : bytes
+            a bytes representation of a BlockBuffer
+
+        Returns
+        -------
+        bool
+            True if the ZeroStream owns this buffer
+        """
+        return (buffer[0] == b"\0") and (buffer[1] == b"\0")
+
+    def generate(self, block_number, block_size):
+        """Generate a buffer for the ZeroStream at a given location
+
+        Parameters
+        ----------
+        block_number : int
+            location in the ZeroStream to generate the buffer
+        block_size : int
+            size of the buffer to generate
+
+        Returns
+        -------
+        bytes
+            the bytes array
+        """
+        return b"\0" * block_size
+
+    def report(self):
+        """Return information about the last write or verify"""
+        return "ZERO: " + str(self.counter)
+
+class BlockRange():
+    """A range of blocks in a file or device
+
+    Raises
+    ------
+    OsError
+    ValueError
+    CompareError
+    FileNotFoundError
+
+    """
+    def __init__(self,
+                 path: str,
+                 block_count: int = 1,
+                 block_size: int = 4096,
+                 offset: int = 0):
+        self.path = self.validate_path(path)
+        self.block_count = block_count
+        self.block_size = block_size
+        self.offset = offset
+        self.create = False
+        self.streams: List[DataStream] = []
+
+    def report(self):
+        """Report on all streams associated with this block range"""
+        list(map(lambda x: x.report(self), self.streams))
+
+    def _seek(self, fd):
+        """Seek to the start of the block range
+
+        Parameters
+        ----------
+        fd : the file descriptor associated with the block range
+        """
+        fd.seek(self.block_size * self.offset)
+
+    def trim(self):
+        """Trim the block range
+
+        This does not actually send discards. The assumption here is that discards
+        have already been sent. This merely will reset the block range so that it
+        will behave properly.
+
+        """
+        stream = ZeroStream()
+        self.streams.clear()
+        self.streams.append(stream)
+
+    def validate_path(self, value: str):
+        """Validate the file or device parameter
+
+        Parameters
+        ----------
+        value : str
+            the file or path parameter
+
+        Raises
+        ------
+        FileNotFoundError
+
+        """
+        if value is None:
+            return None
+        path = Path(value)
+        if (path.is_file() or path.is_block_device()):
+            return path
+        raise FileNotFoundError(value)
+
+    def verify(self):
+        """Verify the data previously written to a block range.
+
+        Raises
+        ------
+        ValueError
+
+        """
+        if self.path is None:
+            raise ValueError("the file/device path is invalid")
+
+        flags = os.O_RDONLY
+        with os.fdopen(os.open(self.path, flags), "rb") as fd:
+            self._seek(fd)
+            for n in range(0, self.block_count):
+                data = fd.read(self.block_size)
+                self.verify_streams(n, data)
+
+    def verify_streams(self, block_number: int, actual: bytes):
+        """Verify all streams related to a specific block in a block range.
+
+        Parameters
+        ----------
+        block_number : int
+            block number to verify all streams against
+        actual : bytes
+            the bytes to compare against
+
+        Raises
+        ------
+        CompareError
+
+        """
+        for stream in self.streams:
+            if stream.claim(actual):
+                expected = stream.generate(block_number, self.block_size)
+                if expected == actual:
+                    stream.counter += 1
+                    return
+                for i in range(0, self.block_size):
+                    if actual[i] != expected[i]:
+                        raise CompareError(block_number, actual, expected, i)
+        raise ClaimError(block_number, actual)
+
+    def write(self,
+              tag: str,
+              dedupe: float = 0.0,
+              compress: float = 0.0,
+              direct: bool = False,
+              sync: bool = False,
+              fsync: bool = False):
+        """Write to a block range
+
+        Parameters
+        ----------
+        tag : str
+            tag the data for future reference
+        dedupe : float
+            how much deduplication to write
+        compress : float
+            how much compressible data to write
+        direct : bool
+            open the device with O_DIRECT
+        sync : bool
+            open the device with O_SYNC
+        fsync : bool
+            write the device with fsync
+
+        Raises
+        ------
+        ValueError
+
+        """
+        if tag is None:
+            raise ValueError("tag is not defined")
+        if len(tag) >= MAX_TAG_SIZE:
+            raise ValueError("tag must be 8 characters or less")
+        if (dedupe < 0) or (dedupe > 1.00):
+            raise ValueError("the dedupe fraction " + str(dedupe)
+                             + " is invalid")
+        # This attempts to handle the space used by the header in all blocks
+        if (compress < 0.0) or (compress > 0.96):
+            raise ValueError("the compression fraction " + str(compress)
+                             + " is invalid")
+        stream = BlockStream(tag, dedupe, compress, direct, sync, fsync)
+
+        flags = os.O_WRONLY
+        if stream.sync:
+            flags |= os.O_SYNC
+        if self.create:
+            flags |= os.O_CREAT
+
+        with os.fdopen(os.open(self.path, flags), "r+b") as fd:
+            self._seek(fd)
+            for n in range(0, self.block_count):
+                data = stream.generate(n, self.block_size)
+                fd.write(data)
+                stream.counter += 1
+            if stream.fsync:
+                os.fsync(fd)
+        self.streams.append(stream)
+
+def make_block_range(path: str,
+                     block_count: int = 1,
+                     block_size: int = 4096,
+                     offset: int = 0) -> BlockRange:
+    """Used to write data for testing
+
+    Creates a range of blocks within a device or file. The range can produce both
+    dedupe and compressed data. It can provide the following
+    operations:
+
+    Parameters
+    ----------
+    path : str
+        path to a file or device
+    block_count : int
+        number of blocks in the block range
+    block_size : int
+        size of each block in the range (in bytes)
+    offset : int
+        offset in the device or file the block range begins at
+
+    Returns
+    -------
+    BlockRange
+         the block range
+
+    """
+    return BlockRange(path, block_count, block_size, offset)

--- a/src/dmtest/vdo/dedupe_tests.py
+++ b/src/dmtest/vdo/dedupe_tests.py
@@ -1,7 +1,9 @@
 from dmtest.assertions import assert_near
 from dmtest.vdo.utils import standard_vdo, wait_for_index
 import dmtest.fs as fs
+import dmtest.gendatablocks as generator
 import dmtest.process as process
+import dmtest.utils as utils
 import dmtest.vdo.stats as stats
 
 import os
@@ -9,72 +11,41 @@ import re
 import logging as log
 import time
 
-#---------------------------------
-
-def make_delta_stats(stats_post, stats_pre):
-    """
-    Given two stats dicts, the code creates a copy of post_stats except all
-    its int fields values are the delta between post and pre.
-    """
-    if isinstance(stats_post, dict):
-        node = {}
-        for key, value in stats_post.items():
-            node[key] = make_delta_stats(value, stats_pre[key])
-        return node
-    elif isinstance(stats_post, int):
-        return stats_post - stats_pre
-    return stats_post
-
-def get_dataset_config():
-    config = {
-        "gen.large.num" : 32,
-        "gen.large.min" : 4 * 1024 * 1024,
-        "gen.large.max" : 4 * 1024 * 1024,
-    }
-    return config
-
-def verify_dedupe(vdo, fs_type, dedupe):
+def verify_dedupe(vdo, dedupe: float):
     # Wait for index to be online
     wait_for_index(vdo)
     # Do our usual wait on udev
     process.run("udevadm settle")
 
-    fs = fs_type(vdo)
-    fs.format(discard=False, quiet=True, lazy=False, noreserve=True, bs=4096)
+    # Get stats before any writing
+    stats_pre = stats.vdo_stats(vdo)
 
-    with fs.mount_and_chdir("./mnt"):
-        # Grab the initial stats
-        stats_pre = stats.vdo_stats(vdo)
-        # Generate the files on top of VDO
-        config = get_dataset_config()
-        config["gen.large.numCoalescent"] = int((config["gen.large.num"] * dedupe) / 100)
-        config["gen.root.dir"] = os.getcwd()
-        options = "--stdout --logDir=../"
-        for k, v in config.items():
-            options += " -D" + k + "=" + str(v)
-        gen_data = os.getcwd() + "/../src/scripts/gen_dataset.py"
-        process.run(gen_data +  " " + options)
-        # Grab the current stats and determine the differance between the two,
-        # thus showing what are the stats just for the gen_data_set call.
-        stats_post = stats.vdo_stats(vdo)
-        stats_delta = make_delta_stats(stats_post, stats_pre)
-        unique_files = config["gen.large.num"] - config["gen.large.numCoalescent"]
-        expected = unique_files / config["gen.large.num"]
-        actual = stats_delta["dataBlocksUsed"] / stats_delta["logicalBlocksUsed"]
-        log.info(f"expected: {expected}, found: {actual}")
-        assert_near(actual, expected, 0.1)
+    # Write 5000 4k blocks of specified dedupe
+    br = generator.make_block_range(path=vdo.path, block_size=4096, block_count=5000)
+    br.write(tag="tag1", dedupe=dedupe, compress=0.0, direct=True, fsync=True)
+    # Grab the current stats and determine the difference between the two. This
+    # will contain only the information related to just the writing. Compare
+    # the expected dedupe rate vs the actual from the stats.
+    stats_post = stats.vdo_stats(vdo)
+    stats_delta = stats.make_delta_stats(stats_post, stats_pre)
+    blocks_written = stats_delta["logicalBlocksUsed"]
+    blocks_deduped = blocks_written - stats_delta["dataBlocksUsed"]
+    actual = float(blocks_deduped / blocks_written)
+    assert_near(actual, dedupe, 0.01)
+    # Verify that the data on disk is what we wrote
+    br.verify()
 
 def t_dedupe0(fix):
     with standard_vdo(fix) as vdo:
-        verify_dedupe(vdo, fs.Ext4, 0)
+        verify_dedupe(vdo, 0.0)
 
 def t_dedupe50(fix):
     with standard_vdo(fix) as vdo:
-        verify_dedupe(vdo, fs.Ext4, 50)
+        verify_dedupe(vdo, 0.50)
 
 def t_dedupe75(fix):
     with standard_vdo(fix) as vdo:
-        verify_dedupe(vdo, fs.Ext4, 75)
+        verify_dedupe(vdo, 0.75)
 
 
 def register(tests):

--- a/src/dmtest/vdo/stats.py
+++ b/src/dmtest/vdo/stats.py
@@ -8,6 +8,20 @@ import yaml
 def _parse_vdo_stats(stats):
     return yaml.safe_load(stats)
 
+def make_delta_stats(stats_post, stats_pre):
+    """
+    Given two stats dicts, the code creates a copy of post_stats except all
+    its int fields values are the delta between post and pre.
+    """
+    if isinstance(stats_post, dict):
+        node = {}
+        for key, value in stats_post.items():
+            node[key] = make_delta_stats(value, stats_pre[key])
+        return node
+    elif isinstance(stats_post, int):
+        return stats_post - stats_pre
+    return stats_post
+
 def vdo_stats(dev):
     os.sync()
     stats = dev.message(0, "stats"); 


### PR DESCRIPTION
gendatablocks is a python library that can be used to write test data to a block device, file, or directory. 

The main class in gendatablocks is a BlockRange. A BlockRange is a contiguous range of blocks in one of the three locations mentioned above. Along with a BlockRange, gendatablocks also uses a DataStream class, which describes how data will be generated. A DataStream will operate on a BlockRange object, causing test data to be generated and written to disk. Once data is written, the DataStream and BlockRange can also be used to verify the data was properly written.  