### PR TITLE
Added new Direct01/testBasic test

### DIFF
--- a/src/dmtest/vdo/compress_tests.py
+++ b/src/dmtest/vdo/compress_tests.py
@@ -1,17 +1,10 @@
 from dmtest.assertions import assert_equal, assert_near
 from dmtest.vdo.stats import vdo_stats
-from dmtest.vdo.utils import discard, fsync, run_fio, standard_vdo, wait_for_index
+from dmtest.vdo.utils import BLOCK_SIZE, MB, discard, fsync, run_fio, standard_vdo, wait_for_index
 import dmtest.process as process
 
 import logging as log
 import time
-
-# dmtest.units.kilo etc count in sectors, not bytes
-kB = 1024
-MB = 1024 * kB
-GB = 1024 * MB
-
-BLOCK_SIZE = 4 * kB
 
 def wait_until_packer_only(vdo):
     """Waits until all the I/Os being processed by a VDO device are

--- a/src/dmtest/vdo/compress_tests.py
+++ b/src/dmtest/vdo/compress_tests.py
@@ -1,31 +1,10 @@
-from dmtest.assertions import assert_near, assert_equal
-from dmtest.vdo.utils import standard_vdo, wait_for_index, discard, fsync
-import dmtest.process as process
+from dmtest.assertions import assert_equal, assert_near
 from dmtest.vdo.stats import vdo_stats
+from dmtest.vdo.utils import discard, fsync, run_fio, standard_vdo, wait_for_index
+import dmtest.process as process
 
-import json
 import logging as log
-import tempfile
 import time
-
-fio_config_template = """
-[stuff]
-randrepeat=1
-ioengine=libaio
-bs=4k
-size={size}
-rw=write
-direct=1
-scramble_buffers=1
-buffer_compress_percentage={compress}
-buffer_compress_chunk=4k
-filename={filename}
-iodepth=128
-offset={offset}
-end_fsync=0
-{maybe_verify}
-group_reporting=1
-"""
 
 # dmtest.units.kilo etc count in sectors, not bytes
 kB = 1024
@@ -33,28 +12,6 @@ MB = 1024 * kB
 GB = 1024 * MB
 
 BLOCK_SIZE = 4 * kB
-
-def run_fio(dev, size, offset, verify = False, stats = True):
-    fio_config = fio_config_template.format(size=size,
-                                            offset=offset,
-                                            compress=74,
-                                            filename=str(dev),
-                                            maybe_verify = "verify_only" if verify else "")
-    log.info("fio config:\n" + fio_config)
-    with tempfile.NamedTemporaryFile('w') as conf:
-        conf.write(fio_config)
-        conf.flush()
-        if stats:
-            with tempfile.NamedTemporaryFile('w') as out:
-                process.run(f"fio {conf.name} --output={out.name} --output-format=json+")
-                fio_out = json.load(open(out.name, 'r'))
-                written = fio_out['jobs'][0]['write']['io_bytes'] # bytes
-                duration = fio_out['jobs'][0]['write']['runtime'] # msec
-                #log.info(fio_out)
-                log.info(f"wrote {written} bytes in {duration} msec")
-                return fio_out
-        else:
-            process.run(f"fio {conf.name}")
 
 def wait_until_packer_only(vdo):
     """Waits until all the I/Os being processed by a VDO device are
@@ -84,7 +41,7 @@ def t_compress(fix):
         log.info(f"data blocks used: {stats['dataBlocksUsed']}")
         wait_for_index(vdo)
         # No flushing here!
-        run_fio(vdo, size, 0)
+        run_fio(vdo, size, 0, compression=74)
         # Flushing will cause I/Os in the packer to be pushed out;
         # there could be a bin with only one entry, which will get
         # written out uncompressed, or two entries, but (with the
@@ -117,7 +74,7 @@ def t_compress(fix):
                      'dedupe advice valid (1st write)')
         # Write same data again, different location.
         # Confirm we deduplicate against compressed blocks.
-        run_fio(vdo, size, size)
+        run_fio(vdo, size, size, compression=74)
         stats2 = wait_until_packer_only(vdo)
         assert_equal(stats2['dataBlocksUsed'], stats['dataBlocksUsed'],
                      'data blocks used (2nd write)')
@@ -128,7 +85,7 @@ def t_compress(fix):
         assert_equal(stats2['hashLock']['dedupeAdviceValid'],
                      size_in_blocks, 'dedupe advice valid (2nd write)')
         # Confirm we can read back compressed data correctly.
-        run_fio(vdo, size, 0, verify=True, stats=False)
+        run_fio(vdo, size, 0, verify=True, stats=False, compression=74)
         # Check recovery of unreferenced compressed data.
         discard(vdo, 2 * size, 0)
         fsync(vdo)

--- a/src/dmtest/vdo/compress_tests.py
+++ b/src/dmtest/vdo/compress_tests.py
@@ -1,12 +1,10 @@
 from dmtest.assertions import assert_near, assert_equal
 from dmtest.vdo.utils import standard_vdo, wait_for_index, discard, fsync
-import dmtest.fs as fs
 import dmtest.process as process
 from dmtest.vdo.stats import vdo_stats
 
 import json
 import logging as log
-import os
 import tempfile
 import time
 

--- a/src/dmtest/vdo/creation_tests.py
+++ b/src/dmtest/vdo/creation_tests.py
@@ -1,11 +1,4 @@
-from dmtest.assertions import assert_raises
-from dmtest.vdo.utils import standard_stack, standard_vdo
-import dmtest.device_mapper.dev as dmdev
-import dmtest.vdo.vdo_stack as vs
-import dmtest.tvm as tvm
-import dmtest.units as units
-import dmtest.utils as utils
-
+from dmtest.vdo.utils import standard_vdo
 
 def t_create(fix):
     with standard_vdo(fix) as vdo:

--- a/src/dmtest/vdo/dedupe_tests.py
+++ b/src/dmtest/vdo/dedupe_tests.py
@@ -1,15 +1,8 @@
 from dmtest.assertions import assert_near
 from dmtest.vdo.utils import standard_vdo, wait_for_index
-import dmtest.fs as fs
 import dmtest.gendatablocks as generator
 import dmtest.process as process
-import dmtest.utils as utils
 import dmtest.vdo.stats as stats
-
-import os
-import re
-import logging as log
-import time
 
 def verify_dedupe(vdo, dedupe: float):
     # Wait for index to be online

--- a/src/dmtest/vdo/dedupe_tests.py
+++ b/src/dmtest/vdo/dedupe_tests.py
@@ -1,5 +1,5 @@
-from dmtest.assertions import assert_near
-from dmtest.vdo.utils import standard_vdo, wait_for_index
+from dmtest.assertions import assert_equal, assert_near
+from dmtest.vdo.utils import BLOCK_SIZE, fsync, run_fio, standard_vdo, wait_for_index
 import dmtest.gendatablocks as generator
 import dmtest.process as process
 import dmtest.vdo.stats as stats
@@ -40,6 +40,49 @@ def t_dedupe75(fix):
     with standard_vdo(fix) as vdo:
         verify_dedupe(vdo, 0.75)
 
+def t_dedupeWithOffsetAndRestart(fix):
+    """
+    Write the same data at two offsets and ensure that VDO statistics reflect
+    the appropriate values
+
+    After writing the data for the first round:
+        dataBlocksUsed should equal the total number of blocks written
+        entriesIndexed should equal the total number of blocks written
+
+    After writing the same data a second time:
+        dedupeAdviceValid should equal the number of blocks written originally
+    """
+    block_count = 5000
+    size = int(block_count * BLOCK_SIZE)
+    with standard_vdo(fix) as vdo:
+        # Write {size} data at 0 offset
+        run_fio(vdo, size, 0)
+
+        # Ensure data is stable before checking stats
+        fsync(vdo)
+
+        # Verify first round statistics equal total data written
+        vdo_stats_before = stats.vdo_stats(vdo)
+        assert_equal(vdo_stats_before['dataBlocksUsed'], block_count)
+        assert_equal(vdo_stats_before['index']['entriesIndexed'], block_count)
+
+        # Write {size} data at {size} offset
+        run_fio(vdo, size, size)
+
+        # Ensure data is stable before checking stats
+        fsync(vdo)
+
+        # Verify second round statistics reflect effective deduplication
+        vdo_stats_after = stats.vdo_stats(vdo)
+        assert_equal(vdo_stats_after['hashLock']['dedupeAdviceValid'], block_count)
+
+    # Re-assemble the VDO device, but this time without formatting
+    with standard_vdo(fix, format=False) as vdo:
+        # Verify the first set of data is still correct
+        run_fio(vdo, size, 0, verify=True)
+
+        # Verify the second set of data is still correct
+        run_fio(vdo, size, size, verify=True)
 
 def register(tests):
     tests.register_batch(
@@ -48,5 +91,6 @@ def register(tests):
             ("dedupe0", t_dedupe0),
             ("dedupe50", t_dedupe50),
             ("dedupe75", t_dedupe75),
+            ("dedupeWithOffsetAndRestart", t_dedupeWithOffsetAndRestart),
         ],
     )

--- a/src/dmtest/vdo/stats.py
+++ b/src/dmtest/vdo/stats.py
@@ -1,9 +1,5 @@
-import dmtest.process as process
-
 import os
-import re
 import yaml
-
 
 def _parse_vdo_stats(stats):
     return yaml.safe_load(stats)
@@ -24,5 +20,5 @@ def make_delta_stats(stats_post, stats_pre):
 
 def vdo_stats(dev):
     os.sync()
-    stats = dev.message(0, "stats"); 
+    stats = dev.message(0, "stats");
     return _parse_vdo_stats(stats)

--- a/src/dmtest/vdo/status.py
+++ b/src/dmtest/vdo/status.py
@@ -1,6 +1,5 @@
 import re
 
-
 def _parse_vdo_status(str):
     tokens = re.split(r"\s+", str)
 

--- a/src/dmtest/vdo/utils.py
+++ b/src/dmtest/vdo/utils.py
@@ -24,6 +24,7 @@ size={size}
 rw=write
 direct=1
 scramble_buffers=1
+refill_buffers=1
 buffer_compress_percentage={compress}
 buffer_compress_chunk=4k
 filename={filename}

--- a/src/dmtest/vdo/utils.py
+++ b/src/dmtest/vdo/utils.py
@@ -1,9 +1,31 @@
 import dmtest.process as process
 import dmtest.vdo.vdo_stack as vs
 import dmtest.vdo.status as status
+import logging as log
 
+import json
 import os
+import tempfile
 import time
+
+fio_config_template = """
+[stuff]
+randrepeat=1
+ioengine=libaio
+bs=4k
+size={size}
+rw=write
+direct=1
+scramble_buffers=1
+buffer_compress_percentage={compress}
+buffer_compress_chunk=4k
+filename={filename}
+iodepth=128
+offset={offset}
+end_fsync=0
+{maybe_verify}
+group_reporting=1
+"""
 
 def standard_stack(fix, **opts):
     cfg = fix.cfg
@@ -28,3 +50,25 @@ def fsync(dev):
     """Sync the specified device or file."""
     with open(dev, 'w') as thing:
         os.fsync(thing.fileno())
+
+def run_fio(dev, size, offset, verify = False, stats = True, compression = 0):
+    fio_config = fio_config_template.format(size=size,
+                                            offset=offset,
+                                            compress=compression,
+                                            filename=str(dev),
+                                            maybe_verify = "verify_only" if verify else "")
+    log.info("fio config:\n" + fio_config)
+    with tempfile.NamedTemporaryFile('w') as conf:
+        conf.write(fio_config)
+        conf.flush()
+        if stats:
+            with tempfile.NamedTemporaryFile('w') as out:
+                process.run(f"fio {conf.name} --output={out.name} --output-format=json+")
+                fio_out = json.load(open(out.name, 'r'))
+                written = fio_out['jobs'][0]['write']['io_bytes'] # bytes
+                duration = fio_out['jobs'][0]['write']['runtime'] # msec
+                #log.info(fio_out)
+                log.info(f"wrote {written} bytes in {duration} msec")
+                return fio_out
+        else:
+            process.run(f"fio {conf.name}")

--- a/src/dmtest/vdo/utils.py
+++ b/src/dmtest/vdo/utils.py
@@ -8,6 +8,13 @@ import os
 import tempfile
 import time
 
+# dmtest.units.kilo etc count in sectors, not bytes
+kB = 1024
+MB = 1024 * kB
+GB = 1024 * MB
+
+BLOCK_SIZE = 4 * kB
+
 fio_config_template = """
 [stuff]
 randrepeat=1

--- a/src/dmtest/vdo/vdo_stack.py
+++ b/src/dmtest/vdo/vdo_stack.py
@@ -5,7 +5,6 @@ import dmtest.utils as utils
 
 from dmtest.process import run
 
-
 class VDOStack:
     def __init__(self, data_dev, **opts):
         self._data_dev = data_dev
@@ -20,14 +19,13 @@ class VDOStack:
         self._opts = opts
 
         if self._format:
-            logical_size = "--logical-size=" + str(self._logical_size) + "B" 
+            logical_size = "--logical-size=" + str(self._logical_size) + "B"
             mem = "--uds-memory-size=" + str(self._alb_mem)
             sparse = ""
             if self._alb_sparse:
                 sparse = " --uds-sparse"
             dev = self._data_dev
             run(f"vdoformat --force {logical_size} {mem}{sparse} {dev}")
-
 
     def _vdo_table(self):
         return table.Table(
@@ -42,7 +40,5 @@ class VDOStack:
             )
         )
 
-
     def activate(self):
         return dmdev.dev(self._vdo_table())
-


### PR DESCRIPTION
Here is a log showing a successful run of the new test:
```
# ./dmtest run /vdo/dedupe/direct01_testBasic --result-set vdo-test --log
vdo
  dedupe
    direct01_testBasic                            2024-07-30 17:51:45,537 INFO Running '/vdo/dedupe/direct01_testBasic'
2024-07-30 17:51:45,537 INFO running: 'blockdev --getsz /dev/vdb'
2024-07-30 17:51:45,542 INFO stdout:
83886080
2024-07-30 17:51:45,543 INFO running: 'vdoformat --force --logical-size=21474836480B --uds-memory-size=0.25 /dev/vdb'
2024-07-30 17:51:45,864 INFO stdout:
Found existing signature on /dev/vdb at offset 82: LABEL="ephemeral0" UUID="85A3-7648" TYPE="vfat" USAGE="filesystem".
Formatting device already containing a known signature.
The VDO volume can address 36.00 GB in 18 data slabs, each 2.00 GB.
It can grow to address at most 16.00 TB of physical storage in 8192 slabs.
If a larger maximum size might be needed, use bigger slabs.
2024-07-30 17:51:45,864 INFO running: 'dmsetup create test-dev-43754 --notable'
2024-07-30 17:51:45,871 INFO table file '/tmp/tmpce2afzys':
0 41943040 vdo V4 /dev/vdb 10485760 4096 32768 16380
2024-07-30 17:51:45,872 INFO running: 'dmsetup load test-dev-43754 /tmp/tmpce2afzys'
2024-07-30 17:51:45,967 INFO running: 'dmsetup resume test-dev-43754'
2024-07-30 17:51:46,029 INFO fio config:

[stuff]
randrepeat=1
ioengine=libaio
bs=4k
size=20480000
rw=write
direct=1
scramble_buffers=1
buffer_compress_percentage=74
buffer_compress_chunk=4k
filename=/dev/mapper/test-dev-43754
iodepth=128
offset=0
end_fsync=0

group_reporting=1

2024-07-30 17:51:46,030 INFO running: 'fio /tmp/tmpn7owk_ez --output=/tmp/tmpmqaaoav0 --output-format=json+'
2024-07-30 17:51:46,629 INFO wrote 20480000 bytes in 144 msec
2024-07-30 17:51:46,644 INFO running: 'dmsetup message test-dev-43754 0 stats'
2024-07-30 17:51:46,654 INFO stdout:
{ version : 36, dataBlocksUsed : 5000, overheadBlocksUsed : 1054976, logicalBlocksUsed : 5000, physicalBlocks : 10485760, logicalBlocks : 5242880, blockMapCacheSize : 134217728, blockSize : 4096, completeRecoveries : 0, readOnlyRecoveries : 0, mode : normal, inRecoveryMode : 0, recoveryPercentage : 100, packer : { compressedFragmentsWritten : 0, compressedBlocksWritten : 0, compressedFragmentsInPacker : 0, }, allocator : { slabCount : 18, slabsOpened : 1, slabsReopened : 0, }, journal : { diskFull : 0, slabJournalCommitsRequested : 0, entries : { started : 5028, written : 5028, committed : 5028, }, blocks : { started : 59, written : 59, committed : 59, }, }, slabJournal : { diskFullCount : 0, flushCount : 0, blockedCount : 0, blocksWritten : 3, tailBusyCount : 0, }, slabSummary : { blocksWritten : 3, }, refCounts : { blocksWritten : 0, }, blockMap : { dirtyPages : 7, cleanPages : 0, freePages : 32761, failedPages : 0, incomingPages : 0, outgoingPages : 0, cachePressure : 0, readCount : 5264, writeCount : 5000, failedReads : 0, failedWrites : 0, reclaimed : 0, readOutgoing : 0, foundInCache : 8667, discardRequired : 0, waitForPage : 1590, fetchRequired : 7, pagesLoaded : 7, pagesSaved : 0, flushCount : 0, }, hashLock : { dedupeAdviceValid : 0, dedupeAdviceStale : 0, concurrentDataMatches : 0, concurrentHashCollisions : 0, currDedupeQueries : 0, }, errors : { invalidAdvicePBNCount : 0, noSpaceErrorCount : 0, readOnlyErrorCount : 0, }, instance : 0, currentVIOsInProgress : 0, maxVIOs : 940, dedupeAdviceTimeouts : 0, flushOut : 1, logicalBlockSize : 4096, biosIn : { read : 1048, write : 5000, emptyFlush : 1, discard : 0, flush : 1, fua : 0, }, biosInPartial : { read : 0, write : 0, emptyFlush : 0, discard : 0, flush : 0, fua : 0, }, biosOut : { read : 264, write : 5000, emptyFlush : 0, discard : 0, flush : 0, fua : 0, }, biosMeta : { read : 16, write : 67, emptyFlush : 3, discard : 0, flush : 66, fua : 60, }, biosJournal : { read : 0, write : 59, emptyFlush : 3, discard : 0, flush : 62, fua : 59, }, biosPageCache : { read : 7, write : 0, emptyFlush : 0, discard : 0, flush : 0, fua : 0, }, biosOutCompleted : { read : 264, write : 5000, emptyFlush : 0, discard : 0, flush : 0, fua : 0, }, biosMetaCompleted : { read : 16, write : 4, emptyFlush : 66, discard : 0, flush : 66, fua : 0, }, biosJournalCompleted : { read : 0, write : 0, emptyFlush : 62, discard : 0, flush : 62, fua : 0, }, biosPageCacheCompleted : { read : 7, write : 0, emptyFlush : 0, discard : 0, flush : 0, fua : 0, }, biosAcknowledged : { read : 1048, write : 5000, emptyFlush : 1, discard : 0, flush : 1, fua : 0, }, biosAcknowledgedPartial : { read : 0, write : 0, emptyFlush : 0, discard : 0, flush : 0, fua : 0, }, biosInProgress : { read : 0, write : 0, emptyFlush : 0, discard : 0, flush : 0, fua : 0, }, memoryUsage : { bytesUsed : 418329696, peakBytesUsed : 418329696, }, index : { entriesIndexed : 5000, postsFound : 0, postsNotFound : 5000, queriesFound : 0, queriesNotFound : 0, updatesFound : 0, updatesNotFound : 0, entriesDiscarded : 0, }, }
2024-07-30 17:51:46,667 INFO fio config:

[stuff]
randrepeat=1
ioengine=libaio
bs=4k
size=20480000
rw=write
direct=1
scramble_buffers=1
buffer_compress_percentage=74
buffer_compress_chunk=4k
filename=/dev/mapper/test-dev-43754
iodepth=128
offset=20480000
end_fsync=0

group_reporting=1

2024-07-30 17:51:46,667 INFO running: 'fio /tmp/tmp9n3gwd48 --output=/tmp/tmpwuon0b1h --output-format=json+'
2024-07-30 17:51:46,990 INFO wrote 20480000 bytes in 108 msec
2024-07-30 17:51:46,991 INFO running: 'dmsetup message test-dev-43754 0 stats'
2024-07-30 17:51:47,004 INFO stdout:
{ version : 36, dataBlocksUsed : 5000, overheadBlocksUsed : 1055000, logicalBlocksUsed : 10000, physicalBlocks : 10485760, logicalBlocks : 5242880, blockMapCacheSize : 134217728, blockSize : 4096, completeRecoveries : 0, readOnlyRecoveries : 0, mode : normal, inRecoveryMode : 0, recoveryPercentage : 100, packer : { compressedFragmentsWritten : 0, compressedBlocksWritten : 0, compressedFragmentsInPacker : 0, }, allocator : { slabCount : 18, slabsOpened : 1, slabsReopened : 0, }, journal : { diskFull : 0, slabJournalCommitsRequested : 0, entries : { started : 10052, written : 10052, committed : 10052, }, blocks : { started : 114, written : 114, committed : 114, }, }, slabJournal : { diskFullCount : 0, flushCount : 0, blockedCount : 0, blocksWritten : 7, tailBusyCount : 0, }, slabSummary : { blocksWritten : 7, }, refCounts : { blocksWritten : 0, }, blockMap : { dirtyPages : 13, cleanPages : 0, freePages : 32755, failedPages : 0, incomingPages : 0, outgoingPages : 0, cachePressure : 0, readCount : 10538, writeCount : 10000, failedReads : 0, failedWrites : 0, reclaimed : 0, readOutgoing : 0, foundInCache : 18840, discardRequired : 0, waitForPage : 1685, fetchRequired : 13, pagesLoaded : 13, pagesSaved : 0, flushCount : 0, }, hashLock : { dedupeAdviceValid : 5000, dedupeAdviceStale : 0, concurrentDataMatches : 0, concurrentHashCollisions : 0, currDedupeQueries : 0, }, errors : { invalidAdvicePBNCount : 0, noSpaceErrorCount : 0, readOnlyErrorCount : 0, }, instance : 0, currentVIOsInProgress : 1, maxVIOs : 940, dedupeAdviceTimeouts : 0, flushOut : 2, logicalBlockSize : 4096, biosIn : { read : 1598, write : 10000, emptyFlush : 2, discard : 0, flush : 2, fua : 0, }, biosInPartial : { read : 0, write : 0, emptyFlush : 0, discard : 0, flush : 0, fua : 0, }, biosOut : { read : 5538, write : 5000, emptyFlush : 0, discard : 0, flush : 0, fua : 0, }, biosMeta : { read : 28, write : 130, emptyFlush : 7, discard : 0, flush : 129, fua : 115, }, biosJournal : { read : 0, write : 114, emptyFlush : 7, discard : 0, flush : 121, fua : 114, }, biosPageCache : { read : 13, write : 0, emptyFlush : 0, discard : 0, flush : 0, fua : 0, }, biosOutCompleted : { read : 5537, write : 5000, emptyFlush : 0, discard : 0, flush : 0, fua : 0, }, biosMetaCompleted : { read : 28, write : 8, emptyFlush : 129, discard : 0, flush : 129, fua : 0, }, biosJournalCompleted : { read : 0, write : 0, emptyFlush : 121, discard : 0, flush : 121, fua : 0, }, biosPageCacheCompleted : { read : 13, write : 0, emptyFlush : 0, discard : 0, flush : 0, fua : 0, }, biosAcknowledged : { read : 1597, write : 10000, emptyFlush : 2, discard : 0, flush : 2, fua : 0, }, biosAcknowledgedPartial : { read : 0, write : 0, emptyFlush : 0, discard : 0, flush : 0, fua : 0, }, biosInProgress : { read : 1, write : 0, emptyFlush : 0, discard : 0, flush : 0, fua : 0, }, memoryUsage : { bytesUsed : 418329696, peakBytesUsed : 418329696, }, index : { entriesIndexed : 5000, postsFound : 5000, postsNotFound : 5000, queriesFound : 0, queriesNotFound : 0, updatesFound : 0, updatesNotFound : 0, entriesDiscarded : 0, }, }
2024-07-30 17:51:47,017 INFO running: 'dmsetup remove test-dev-43754'
2024-07-30 17:51:47,557 INFO running: 'blockdev --getsz /dev/vdb'
2024-07-30 17:51:47,561 INFO stdout:
83886080
2024-07-30 17:51:47,561 INFO running: 'dmsetup create test-dev-689279 --notable'
2024-07-30 17:51:47,565 INFO table file '/tmp/tmplirv1mid':
0 41943040 vdo V4 /dev/vdb 10485760 4096 32768 16380
2024-07-30 17:51:47,565 INFO running: 'dmsetup load test-dev-689279 /tmp/tmplirv1mid'
2024-07-30 17:51:47,612 INFO running: 'dmsetup resume test-dev-689279'
2024-07-30 17:51:47,714 INFO fio config:

[stuff]
randrepeat=1
ioengine=libaio
bs=4k
size=20480000
rw=write
direct=1
scramble_buffers=1
buffer_compress_percentage=74
buffer_compress_chunk=4k
filename=/dev/mapper/test-dev-689279
iodepth=128
offset=0
end_fsync=0
verify_only
group_reporting=1

2024-07-30 17:51:47,715 INFO running: 'fio /tmp/tmpy4w87c6b --output=/tmp/tmpl1_jwg0p --output-format=json+'
2024-07-30 17:51:48,052 INFO wrote 20480000 bytes in 0 msec
2024-07-30 17:51:48,052 INFO fio config:

[stuff]
randrepeat=1
ioengine=libaio
bs=4k
size=20480000
rw=write
direct=1
scramble_buffers=1
buffer_compress_percentage=74
buffer_compress_chunk=4k
filename=/dev/mapper/test-dev-689279
iodepth=128
offset=20480000
end_fsync=0
verify_only
group_reporting=1

2024-07-30 17:51:48,052 INFO running: 'fio /tmp/tmprthtjzcr --output=/tmp/tmph89kzose --output-format=json+'
2024-07-30 17:51:48,375 INFO wrote 20480000 bytes in 0 msec
2024-07-30 17:51:48,375 INFO running: 'dmsetup remove test-dev-689279'
PASS [2.89s]
```

Also verified existing tests still work after the refactoring/updates:
```
# ./dmtest run /vdo/ --result-set vdo-test
vdo
  compress
    compress                                      PASS [1.65s]
  creation
    create01                                      PASS [0.36s]
  dedupe
    dedupe0                                       PASS [2.41s]
    dedupe50                                      PASS [2.75s]
    dedupe75                                      PASS [2.61s]
    direct01_testBasic                            PASS [2.69s]
```

Signed-off-by: Andrew Walsh <awalsh@redhat.com>