### PR TITLE
Implement issuing discards in BlockRange.trim method

### DIFF
--- a/src/dmtest/gendatablocks.py
+++ b/src/dmtest/gendatablocks.py
@@ -406,6 +406,8 @@ class BlockRange():
         CompareError
 
         """
+        if self.streams == []:
+            logging.warning("no streams available to claim data")
         for stream in self.streams:
             if stream.claim(actual):
                 expected = stream.generate(block_number, self.block_size)

--- a/src/dmtest/gendatablocks.py
+++ b/src/dmtest/gendatablocks.py
@@ -1,4 +1,6 @@
 """ Write test data to a device or file"""
+import dmtest.process as process
+
 import logging
 import os
 import struct
@@ -338,14 +340,14 @@ class BlockRange():
         """
         fd.seek(self.block_size * self.offset)
 
-    def trim(self):
-        """Trim the block range
-
-        This does not actually send discards. The assumption here is that discards
-        have already been sent. This merely will reset the block range so that it
-        will behave properly.
-
-        """
+    def trim(self, fsync=False):
+        """Trim the block range, if supported."""
+        byte_offset = self.block_size * self.offset
+        byte_size = self.block_size * self.block_count
+        process.run(f"blkdiscard -o {byte_offset} -l {byte_size} {self.path}")
+        if fsync:
+            with open(self.path, "w+") as f:
+                os.fsync(f.fileno())
         stream = ZeroStream()
         self.streams.clear()
         self.streams.append(stream)

--- a/src/dmtest/vdo/compress_tests.py
+++ b/src/dmtest/vdo/compress_tests.py
@@ -1,7 +1,7 @@
 from dmtest.assertions import assert_equal, assert_near
 from dmtest.gendatablocks import make_block_range
 from dmtest.vdo.stats import vdo_stats
-from dmtest.vdo.utils import BLOCK_SIZE, MB, discard, fsync, standard_vdo, wait_for_index
+from dmtest.vdo.utils import BLOCK_SIZE, MB, fsync, standard_vdo, wait_for_index
 import dmtest.process as process
 
 import logging as log
@@ -86,10 +86,8 @@ def t_compress(fix):
         # Confirm we can read back compressed data correctly.
         range1.verify()
         # Check recovery of unreferenced compressed data.
-        discard(vdo, 2 * size, 0)
         range1.trim()
-        range2.trim()
-        fsync(vdo)
+        range2.trim(fsync=True)
         range1.verify()
         range2.verify()
         stats = vdo_stats(vdo)

--- a/src/dmtest/vdo/utils.py
+++ b/src/dmtest/vdo/utils.py
@@ -55,9 +55,6 @@ def wait_for_index(dev):
     if status.vdo_status(dev)["index-state"] != "online":
         raise AssertionError("VDO not online within 30 seconds")
 
-def discard(dev, size, offset):
-    process.run(f"blkdiscard -o {offset} -l {size} {dev}")
-
 def fsync(dev):
     """Sync the specified device or file."""
     with open(dev, 'w') as thing:


### PR DESCRIPTION
Implemented as multiple commits to facilitate rebasing and merging to send upstream.