### PR TITLE
[VDO-5887] Fix vdo/full test

### DIFF
--- a/src/dmtest/vdo/full_tests.py
+++ b/src/dmtest/vdo/full_tests.py
@@ -17,7 +17,7 @@ def get_free_space(stats):
 def t_full(fix):
     data_dev = fix.cfg["data_dev"]
     # Configure a small device so we can fill it quickly.
-    slab_bits = 8
+    slab_bits = 13
     size_gb = 3
     vm = tvm.VM()
     vm.add_allocation_volume(data_dev)


### PR DESCRIPTION
Update the test to use a larger slab size, to conform with the minimum slab size that is now being enforced in vdoformat.